### PR TITLE
Use template literals for relation and rollup checklist entries

### DIFF
--- a/index.js
+++ b/index.js
@@ -341,7 +341,6 @@ function generateChecklist(outPath) {
       checklist += `    **Type:** ${prop.type}\n`;
       if (prop.expression) checklist += `    **Expression:** 
 ${prop.expression}
-`;
       if (prop.relation_id) {
         const relatedDb = output.titles.databases[prop.relation_id];
         checklist += `    **Relation ID:** ${prop.relation_id}\n`;
@@ -387,27 +386,12 @@ ${prop.expression}
       if (prop.type === 'relation') {
         const relatedDb = output.titles.databases[prop.relation_id];
         if (relatedDb) {
-          checklist += `- 
-${db.title}
- → 
-${prop.name}
- → 
-${relatedDb.title}
-`;
+          checklist += `- ${db.title} → ${prop.name} → ${relatedDb.title}\n`;
         }
       } else if (prop.type === 'rollup') {
         const relatedDbForRollup = output.titles.databases[prop.rollup.relation_property_id];
         if (relatedDbForRollup) {
-          checklist += `- 
-${db.title}
- → 
-(rolling up 
-${prop.rollup.rollup_property_name}
- from 
-${relatedDbForRollup.title}
- using 
-${prop.rollup.function}
-`;
+          checklist += `- ${db.title} → ${prop.name} (rolling up ${prop.rollup.rollup_property_name} from ${relatedDbForRollup.title} using ${prop.rollup.function})\n`;
         }
       }
     });


### PR DESCRIPTION
## Summary
- format relation lines with a single template literal including database names
- format rollup lines to show rolled-up property and related database

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node -e` sample snippet verifying checklist output

------
https://chatgpt.com/codex/tasks/task_e_689218c242c0832a93d903a2269472f0