### PR TITLE
Add test for latest scan directory utility

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "scan": "node index.js",
     "transform": "node transform.js --scanDir $(node get-latest-scan-dir.js)",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "keywords": [
     "notion",

--- a/test/get-latest-scan-dir.test.js
+++ b/test/get-latest-scan-dir.test.js
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { execFileSync } from 'node:child_process';
+
+test('get-latest-scan-dir selects most recent directory', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scan-test-'));
+  try {
+    const scriptSrc = path.resolve('get-latest-scan-dir.js');
+    const scriptDest = path.join(tmpDir, 'get-latest-scan-dir.js');
+    fs.copyFileSync(scriptSrc, scriptDest);
+
+    const scansDir = path.join(tmpDir, 'scans');
+    fs.mkdirSync(scansDir);
+
+    const oldDir = path.join(scansDir, 'old');
+    const newDir = path.join(scansDir, 'new');
+    fs.mkdirSync(oldDir);
+    fs.mkdirSync(newDir);
+
+    const oldTime = new Date(0);
+    const newTime = new Date();
+    fs.utimesSync(oldDir, oldTime, oldTime);
+    fs.utimesSync(newDir, newTime, newTime);
+
+    const output = execFileSync(process.execPath, [scriptDest], {
+      encoding: 'utf8',
+    }).trim();
+
+    assert.strictEqual(output, 'new');
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- set up Node's built-in test runner
- add test verifying get-latest-scan-dir picks newest scan directory

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689218ceecf0832a98b400029818bfde