### PR TITLE
Add test for latest scan directory selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "scan": "node index.js",
     "transform": "node transform.js --scanDir $(node get-latest-scan-dir.js)",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "keywords": [
     "notion",

--- a/test/get-latest-scan-dir.test.js
+++ b/test/get-latest-scan-dir.test.js
@@ -1,0 +1,42 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+
+test('selects the most recent scan directory', async () => {
+  const scansDir = path.join(repoRoot, 'scans');
+
+  await fs.mkdir(scansDir, { recursive: true });
+
+  const olderDir = path.join(scansDir, 'older');
+  const newerDir = path.join(scansDir, 'newer');
+
+  await fs.mkdir(olderDir);
+  await fs.mkdir(newerDir);
+
+  const oldTime = new Date(0); // Epoch
+  const newTime = new Date(1000); // Slightly newer
+
+  await fs.utimes(olderDir, oldTime, oldTime);
+  await fs.utimes(newerDir, newTime, newTime);
+
+  try {
+    const { stdout } = await execFileAsync('node', ['get-latest-scan-dir.js'], {
+      cwd: repoRoot,
+    });
+
+    assert.equal(stdout.trim(), 'newer');
+  } finally {
+    await fs.rm(scansDir, { recursive: true, force: true });
+  }
+});
+


### PR DESCRIPTION
## Summary
- Add Node's built-in test for selecting the most recent scan directory
- Run tests with `node --test`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68921ae0ac64832aa5f76a749c729e8b