### PR TITLE
Remove transform script references

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,13 @@
 
 ## 1. Overview
 
-The Notion PLR Inspector is a command-line toolkit designed for developers and power users who work with Notion templates, particularly Private Label Rights (PLR) content. It provides a streamlined workflow to inspect, analyze, and programmatically transform Notion pages and databases.
+The Notion PLR Inspector is a command-line toolkit designed for developers and power users who work with Notion templates, particularly Private Label Rights (PLR) content. It provides a streamlined workflow to inspect and analyze Notion pages and databases.
 
 This toolkit allows you to:
 
 - **Deeply analyze** the structure of a Notion template.
 - **Extract detailed information** about databases, properties, and content blocks.
 - **Generate summaries and quality reports** to quickly understand a template's complexity.
-- **Perform bulk modifications** to Notion content, saving hours of manual work.
-- **Automate the customization** of PLR templates to fit your specific needs.
 
 ## 2. Project Structure
 
@@ -23,15 +21,12 @@ get-latest-scan-dir.js
 index.js
 package.json
 run.sh
-transform.js
 ```
 
 ### 2.1. Core Files
 
 - **`index.js`**: The main script for inspecting a Notion page. It recursively scans the page, extracts its structure and content, and saves the data to a JSON file.
-- **`transform.js`**: This script reads the JSON output from the inspection and applies programmatic transformations to the original Notion page.
-- **`get-latest-scan-dir.js`**: A helper script that identifies the most recent scan directory in the `scans` folder, enabling a seamless workflow between scanning and transforming.
-- **`run.sh`**: A shell script that automates the entire process by running the scan and transform scripts in sequence.
+- **`get-latest-scan-dir.js`**: A helper script that identifies the most recent scan directory in the `scans` folder.
 
 ### 2.2. Configuration Files
 
@@ -52,13 +47,6 @@ This script is the heart of the inspection process. It uses the Notion API to pe
 - **`generateRelationshipSummary()`**: Analyzes the relationships between databases and provides a human-readable summary of how they are linked.
 - **`determineTemplateType()`**: A simple function that attempts to identify the type of template based on the presence of specific databases and relationships (e.g., a "goal-tracker").
 - **`generateQualityReport()`**: Generates a report on the quality of the databases in the template, checking for the presence of titles, relations, formulas, and rollups.
-
-### `transform.js` - The Transformer
-
-This script takes the data from the inspection and uses it to modify the Notion page.
-
-- **`updateParagraphText(blockId, newText)`**: An example function that demonstrates how to update the text of a paragraph block.
-- **`transform()`**: The main function that orchestrates the transformation process. It loads the scan data and includes example transformations, such as adding a prefix to all `heading_1` blocks and rewriting the first paragraph.
 
 ## 4. Getting Started
 
@@ -97,27 +85,9 @@ npm run scan
 
 This will create a new directory in the `scans` folder containing the inspection results.
 
-### 5.2. Transforming a Notion Page
-
-To apply transformations based on the latest scan, run:
-
-```bash
-npm run transform
-```
-
-This will automatically find the most recent scan and use its data to apply the transformations in `transform.js`.
-
-### 5.3. Automated Workflow
-
-To run the entire scan-and-transform process in one command, use the `run.sh` script:
-
-```bash
-./run.sh
-```
-
 ## 6. Customization
 
-The true power of this toolkit lies in its customizability. You can extend the `transform.js` script to perform a wide range of modifications, such as:
+The true power of this toolkit lies in its customizability. You can build on the inspection data to perform a wide range of modifications, such as:
 
 -   Changing rollup formulas
 -   Overwriting specific database fields

--- a/package.json
+++ b/package.json
@@ -1,12 +1,11 @@
 {
   "name": "notion-plr-inspector",
   "version": "1.0.0",
-  "description": "A toolkit for inspecting, summarizing, and transforming Notion templates.",
+  "description": "A toolkit for inspecting and summarizing Notion templates.",
   "main": "index.js",
   "type": "module",
   "scripts": {
     "scan": "node index.js",
-    "transform": "node transform.js --scanDir $(node get-latest-scan-dir.js)",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [

--- a/run.sh
+++ b/run.sh
@@ -6,5 +6,3 @@ set -e
 # Run the scan
 npm run scan
 
-# Run the transform on the latest scan
-npm run transform


### PR DESCRIPTION
## Summary
- Drop `transform.js` script reference in docs and `package.json`
- Simplify `run.sh` to only run the scan workflow

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_689218c5fda4832a9e808236b3a7e20a