### PR TITLE
feat: add GitHub Actions workflow for Notion scans

### DIFF
--- a/.github/workflows/inspect-notion.yml
+++ b/.github/workflows/inspect-notion.yml
@@ -1,0 +1,36 @@
+name: Inspect Notion Template
+
+on:
+  workflow_dispatch:
+    inputs:
+      notionPageId:
+        description: "Notion page ID to scan"
+        required: true
+        default: ""
+
+jobs:
+  inspect:
+    runs-on: ubuntu-latest
+    env:
+      NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
+      NOTION_PAGE_ID: ${{ github.event.inputs.notionPageId }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run Notion PLR Inspector
+        run: node index.js
+
+      - name: Upload output as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: notion-output
+          path: outputs/

--- a/README.md
+++ b/README.md
@@ -1,91 +1,49 @@
-# Notion PLR Inspector
+# 🔍 Notion PLR Inspector
 
-## 1. Overview
+Welcome to **Notion PLR Inspector** — a tiny but mighty 🔧 toolkit for grabbing everything you'd want to know about a Notion template **without** adding any opinions or analysis.
 
-The Notion PLR Inspector is a command-line toolkit designed for developers and power users who work with Notion templates, particularly Private Label Rights (PLR) content. It provides a streamlined workflow to inspect and analyze Notion pages and databases.
+---
 
-This toolkit allows you to:
+## ✨ What It Does
 
-- **Deeply analyze** the structure of a Notion template.
-- **Extract detailed information** about databases, properties, and content blocks.
-- **Generate summaries and quality reports** to quickly understand a template's complexity.
+- 🧠 **Extracts structure** — page titles, block types, column layouts, and nested groups  
+- 🎨 **Captures visuals** — icons, covers, media URLs  
+- 🗄️ **Maps databases** — fields, formulas, relations, and view types  
+- 📝 **Outputs machine-friendly files** — JSON (always) and Markdown (optional)
 
-## 2. Project Structure
+All you get is **pure data**, ready for other GPTs or automation tools to transform, rebrand, or narrate.
+
+---
+
+## 🚀 Quick Start (GitHub Actions)
+
+1. Go to **Actions → Inspect Notion Template → Run workflow**
+2. Enter the Notion page ID you want to scan
+3. Wait for the job to finish, then download the `notion-output` artifact  
+   (Inside you'll find `notion_plr_extracted.json` and any optional extras)
+
+> Make sure you’ve set a `NOTION_API_KEY` secret in your repository settings.
+
+---
+
+## 📂 Output Preview
 
 ```
-.env.example
-.editorconfig
-.gitignore
-.prettierrc.json
-get-latest-scan-dir.js
-index.js
-package.json
-run.sh
+outputs/
+├── notion_plr_extracted.json   # Full structured snapshot
+├── notion_plr_extracted.md     # Optional human-readable outline
+└── db_<name>.json              # Optional database schema dumps
 ```
 
-### 2.1. Core Files
+---
 
-- **`index.js`**: The main script for inspecting a Notion page. It recursively scans the page, extracts its structure and content, and saves the data to a JSON file.
-- **`get-latest-scan-dir.js`**: A helper script that identifies the most recent scan directory in the `scans` folder, enabling a seamless workflow between scans.
-- **`run.sh`**: A shell script that runs the scan script.
-
-### 2.2. Configuration Files
-
-- **`.env.example`**: An example file showing the required environment variables. You should create a `.env` file with your `NOTION_TOKEN` and the `PAGE_ID` of the Notion page you want to inspect.
-- **`package.json`**: Defines the project's metadata, dependencies, and scripts.
-- **`.editorconfig` & `.prettierrc.json`**: Configuration files to ensure consistent code formatting.
-
-## 3. Key Functions and Logic
-
-### `index.js` - The Inspector
-
-This script is the heart of the inspection process. It uses the Notion API to perform a deep dive into a specified Notion page.
-
-- **`inspectDatabase(dbId, indent)`**: Retrieves and analyzes a Notion database, including its properties (relations, formulas, rollups) and a sample of its rows.
-- **`inspectBlock(blockId, indent, parentType)`**: Recursively fetches and processes all blocks on a page, identifying their type and content. It handles nested blocks and child databases.
-- **`extractText(property)`**: A utility function to extract the plain text content from various Notion property types.
-- **`generateSummaries()`**: Creates a high-level summary of the page, including the total number of blocks and databases, the first paragraph of text, and a list of top-level headings.
-- **`generateRelationshipSummary()`**: Analyzes the relationships between databases and provides a human-readable summary of how they are linked.
-- **`determineTemplateType()`**: A simple function that attempts to identify the type of template based on the presence of specific databases and relationships (e.g., a "goal-tracker").
-- **`generateQualityReport()`**: Generates a report on the quality of the databases in the template, checking for the presence of titles, relations, formulas, and rollups.
-
-## 4. Getting Started
-
-### 4.1. Prerequisites
-
-- Node.js (v14 or later)
-- A Notion API key
-
-### 4.2. Installation
-
-1.  **Clone the repository:**
-    ```bash
-    git clone https://github.com/your-username/notion-plr-inspector.git
-    cd notion-plr-inspector
-    ```
-2.  **Install dependencies:**
-    ```bash
-    npm install
-    ```
-3.  **Configure your environment:**
-    Create a `.env` file in the project root and add your Notion API key and the ID of the page you want to inspect:
-    ```
-    NOTION_TOKEN=your_notion_token_here
-    PAGE_ID=your_page_id_here
-    ```
-
-## 5. Usage
-
-### Scanning a Notion Page
-
-To inspect a Notion page and generate a `notion_plr_extracted.json` file, run:
+## 🛠️ Local Development
 
 ```bash
-npm run scan
+npm install
+NOTION_API_KEY=secret_xxx NOTION_PAGE_ID=yyy node index.js
 ```
 
-This will create a new directory in the `scans` folder containing the inspection results.
+---
 
-## 6. License
-
-This project is licensed under the MIT License.
+Happy inspecting! 🕵️‍♀️

--- a/test/get-latest-scan-dir.test.js
+++ b/test/get-latest-scan-dir.test.js
@@ -21,8 +21,10 @@ test('get-latest-scan-dir selects the most recent scan directory', async () => {
     // Create a temporary directory for isolated testing
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'scan-test-'));
 
-    // Define the source path of the script to be tested
-    const scriptSrc = path.resolve(__dirname, 'get-latest-scan-dir.js');
+    // Define the source path of the script to be tested. The implementation
+    // lives one directory up from this test file, so resolve it relative to
+    // the repository root.
+    const scriptSrc = path.resolve(__dirname, '../get-latest-scan-dir.js');
     // Define the destination path within the temporary directory
     const scriptDest = path.join(tmpDir, 'get-latest-scan-dir.js');
 


### PR DESCRIPTION
## Summary
- rewrite README with emoji-rich description and local dev instructions
- add inspect-notion GitHub Actions workflow for on-demand scans
- fix test for get-latest-scan-dir to reference correct script path

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689329923f38832abd1d918130fac085