### PR TITLE
Align GitHub workflow with project setup

### DIFF
--- a/.github/workflows/inspect-notion.yml
+++ b/.github/workflows/inspect-notion.yml
@@ -12,8 +12,8 @@ jobs:
   inspect:
     runs-on: ubuntu-latest
     env:
-      NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
-      NOTION_PAGE_ID: ${{ github.event.inputs.notionPageId }}
+      NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+      PAGE_ID: ${{ github.event.inputs.notionPageId }}
 
     steps:
       - uses: actions/checkout@v4
@@ -26,8 +26,11 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Run tests
+        run: npm test
+
       - name: Run Notion PLR Inspector
-        run: node index.js
+        run: npm run scan
 
       - name: Upload output as artifact
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ notion-plr-inspector/
 ### Local `.env` setup
 
 ```env
-NOTION_API_KEY=secret_xxxx
-NOTION_PAGE_ID=your_template_id
+NOTION_TOKEN=secret_xxxx
+PAGE_ID=your_template_id
 ```
 
 > 🔐 Do not commit your `.env` file. Use GitHub Secrets or platform-specific env variables in production.
@@ -80,7 +80,7 @@ NOTION_PAGE_ID=your_template_id
 
 This project includes a manual GitHub Actions workflow for running the inspector in the cloud.
 
-1. In your repository, go to **Settings → Secrets and variables → Actions** and add a secret named `NOTION_API_KEY` containing your Notion integration token.
+1. In your repository, go to **Settings → Secrets and variables → Actions** and add a secret named `NOTION_TOKEN` containing your Notion integration token.
 2. Open the **Actions** tab and select **Inspect Notion Template**.
 3. Click **Run workflow**, enter the Notion page ID in the input box, and press the green **Run workflow** button.
 4. After the job completes, download the `notion-output` artifact from the run's summary page.


### PR DESCRIPTION
## Summary
- fix GitHub Actions env var names to match `.env` and code
- run tests and use `npm run scan` in Notion inspector workflow
- update README to reflect `NOTION_TOKEN` and `PAGE_ID`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68933afe4be0832a97c069b1f6877acf